### PR TITLE
DB HAFAS: add supported languages

### DIFF
--- a/data/de/db-hafas-mgate.json
+++ b/data/de/db-hafas-mgate.json
@@ -4,10 +4,15 @@
     "hafasMgate": true
   },
   "supportedLanguages": [
-    "en",
     "de",
+    "en",
     "fr",
-    "es"
+    "es",
+    "it",
+    "nl",
+    "da",
+    "pl",
+    "cs"
   ],
   "timezone": "Europe/Berlin",
   "attribution": {


### PR DESCRIPTION
According to https://www.bahn.de/, there are currently nine supported languages. I tested these languages in a sample request and verified that they all work. Not all strings will be translated, but this is a problem that affects `en` as well (like for example the mask and test requirement messages, ironically).

As an aside, do you have any particular method for finding out all supported language codes of a (hafas) provider? Or is this just a try-and-see approach to test which language codes result in `???` message texts?